### PR TITLE
Background GL crash fix.

### DIFF
--- a/Raze/RazeCore/Private/RZXRenderLoop.m
+++ b/Raze/RazeCore/Private/RZXRenderLoop.m
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #import "RZXRenderLoop.h"
+#import "RZXBase.h"
 
 static const NSInteger kRZRenderLoopDefaultFPS = 30;
 
@@ -84,6 +85,7 @@ static const NSInteger kRZRenderLoopDefaultFPS = 30;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
 
     self.valid = YES;
 }
@@ -118,6 +120,16 @@ static const NSInteger kRZRenderLoopDefaultFPS = 30;
     if ( self.pausedWhileInactive && self.automaticallyResumeWhenForegrounded ) {
         [self run];
     }
+}
+
+- (void)willResignActive:(NSNotification *)notification
+{
+	if ( self.isRunning ) {
+		[self stop];
+		self.pausedWhileInactive = YES;
+	}
+	
+	glFinish();
 }
 
 - (void)displayLinkTick:(CADisplayLink *)displayLink


### PR DESCRIPTION
Added willResignActive listener to RZXRenderLoop to pause render loop… and call glFinish().  Prevents background GL crash.

This work done on behalf of Sentient Jet.

See https://developer.apple.com/library/content/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/ImplementingaMultitasking-awareOpenGLESApplication/ImplementingaMultitasking-awareOpenGLESApplication.html
